### PR TITLE
update CI to run formatter, dump fib trace and upload

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,32 +19,80 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang llvm cmake ninja-build valgrind clang-format
-
-    #  for debug
-    # - name: Dump GitHub context
-    #   env:
-    #     GITHUB_CONTEXT: ${{ toJson(github) }}
-    #   run: echo "$GITHUB_CONTEXT"
+        sudo apt-get install -y cmake ninja-build valgrind clang-format
 
     - name: Check format for changed lines
       run: |
         git fetch origin &&
         git diff -U0 origin/${{ github.event.pull_request.base.ref }} | clang-format-diff -p1 -style=LLVM | tee /dev/stderr | grep + && exit 1 || echo format ok
 
+  unittests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build
+
+    - name: Run unit tests
+      run: |
+        cmake -GNinja -Bbuild -DCMAKE_BUILD_TYPE=Debug
+        ninja -Cbuild unittests
+
+  asmtest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang llvm cmake ninja-build
+
     - name: Build
       run: |
         cmake -GNinja -Bbuild -DSANITIZE=ON -DCMAKE_BUILD_TYPE=Debug
         ninja -Cbuild
 
-    - name: Run unit tests
-      run: |
-        ninja -Cbuild unittests
-
     - name: Assemble Test
       run: |
         ninja -Cbuild asmtest
 
+  dump-fib:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build
+
+    - name: Build
+      run: |
+        cmake -GNinja -Bbuild -DSANITIZE=OFF -DCMAKE_BUILD_TYPE=Debug
+        ninja -Cbuild
+
+    - name: Dump
+      run: |
+        wget https://github.com/hashi0203/riscv-processor/raw/main/test-programs/fib.bin
+        # replace jal x0, 0 with nop
+        echo -n -e "\x13\x00\x00\x00" | dd of=fib.bin bs=1 seek=$(( $(stat -c %s fib.bin) - 4)) count=4 conv=notrunc
+        ./build/bin/simkheiv fib.bin 2> dump.txt
+
+    - name: Upload dump
+      uses: actions/upload-artifact@v2
+      with:
+        name: hassy-no-loop-dump.txt
+        path: ./dump.txt
     # FIXME: valgrind with clnag-14 seems like few problems exist.
     # https://github.com/google/sanitizers/issues/856
     # https://hg.mozilla.org/integration/autoland/rev/192810f500b5


### PR DESCRIPTION
1. try to check the code is formatted based on clang-format on CI, like [this](https://github.com/Reservoir-In-Processor/rip-sim/actions/runs/6333985447/job/17202920208#step:5:1). 

2. download [hassy's fib.bin](https://github.com/hashi0203/riscv-processor/blob/main/test-programs/fib.bin) , run simulator and upload registers dump, as we can see [it](https://github.com/Reservoir-In-Processor/rip-sim/actions/runs/6335329814).


And make each tests independent to see what is failed