### PR TITLE
WIP: Make all warnings errors on CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,9 +38,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build
 
-    - name: Run unit tests
+    - name: Run unit tests with -werror
       run: |
-        cmake -GNinja -Bbuild -DCMAKE_BUILD_TYPE=Debug
+        cmake -GNinja -Bbuild -DCMAKE_BUILD_TYPE=Debug -DENABLE_WERROR=ON
         ninja -Cbuild unittests
 
   asmtest:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(asmkheiv CXX)
 # FIXME: this seems bad...
 # set (CMAKE_CXX_COMPILER /usr/bin/clang++ CACHE PATH "" FORCE)
 
-set(CMAKE_CXX_FLAGS "-Werror -Wall -fPIC  ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -fPIC  ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 # for valgrind https://hg.mozilla.org/integration/autoland/rev/192810f500b5
@@ -19,10 +19,15 @@ message(STATUS "build on ${CMAKE_SYSTEM_NAME}, ${CMAKE_SYSTEM_PROCESSOR}")
 
 option(SANITIZE "Enable sanitize options" ON)
 
+option(ENABLE_WERROR "Enable -Werror options" OFF)
+
 if(CMAKE_BUILD_TYPE MATCHES Release)
     set(SANITIZE OFF)
 endif()
 
+if (ENABLE_WERROR)
+  set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+endif()
 if (SANITIZE)
   set(CMAKE_CXX_FLAGS "-fsanitize=undefined ${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "-fsanitize=address ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This will reject all warnings issued by `-Wall`.

This won't be so much annoying. If it will be so we can revert this.

edit: I feel like this will be annoying after reading https://embeddedartistry.com/blog/2017/05/22/werror-is-not-your-friend/

plan to change only CI