### PR TITLE
decode just in time

### DIFF
--- a/include/Simulator/Simulator.h
+++ b/include/Simulator/Simulator.h
@@ -20,7 +20,6 @@ private:
   CSRs States;
   ModeKind Mode;
   GPRegisters GPRegs;
-  std::map<Address, std::unique_ptr<Instruction>> PCInstMap;
 
 public:
   Simulator(const Simulator &) = delete;

--- a/lib/Decoder.cpp
+++ b/lib/Decoder.cpp
@@ -32,8 +32,12 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
       unsigned Imm = InstVal >> 20;
       InstPtr = std::make_unique<IInstruction>(ITypeKinds.find("lhu")->second,
                                                Rd, Rs1, Imm);
-    } else
-      assert(false && "Decoder(Funct3 for load): unimplemented!");
+    } else {
+#ifdef DEBUG
+      dumpInstVal(InstVal);
+#endif
+      return nullptr;
+    }
     break;
 
   case 0b0001111:
@@ -47,8 +51,12 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
       unsigned Imm = 0;
       InstPtr = std::make_unique<IInstruction>(ITypeKinds.find("addi")->second,
                                                Rd, Rs1, Imm);
-    } else
-      assert(false && "Decoder(fence): unimplemented!");
+    } else {
+#ifdef DEBUG
+      dumpInstVal(InstVal);
+#endif
+      return nullptr;
+    }
     break;
 
   case 0b0010111: // auipc
@@ -117,7 +125,7 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
 #ifdef DEBUG
       dumpInstVal(InstVal);
 #endif
-      assert(false && "Decoder(R-types): unimplemented!");
+      return nullptr;
     }
 
     break;
@@ -167,7 +175,7 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
 #ifdef DEBUG
       dumpInstVal(InstVal);
 #endif
-      assert(false && "Decoder(Funct3 for I-types): unimplemented!");
+      return nullptr;
       break;
     }
     break;
@@ -199,7 +207,7 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
 #ifdef DEBUG
       dumpInstVal(InstVal);
 #endif
-      assert(false && "Decoder(Funct3 for store): unimplemented!");
+      return nullptr;
     }
     break;
   case 0b1100011:
@@ -263,7 +271,7 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
 #ifdef DEBUG
         dumpInstVal(InstVal);
 #endif
-        assert(false && "unimplemented!");
+        return nullptr;
       }
       break;
     } else if (Funct3 == 0b001) { // csrrw
@@ -288,21 +296,15 @@ std::unique_ptr<Instruction> Decoder::decode(unsigned InstVal) {
 #ifdef DEBUG
       dumpInstVal(InstVal);
 #endif
-      assert(false && "unimplemented!");
+      return nullptr;
     }
     break;
   default:
 #ifdef DEBUG
     dumpInstVal(InstVal);
 #endif
-    assert(false && "Decoder(Opcode): unimplemented!");
+    return nullptr;
     break;
-  }
-  if (InstPtr == nullptr) {
-#ifdef DEBUG
-    dumpInstVal(InstVal);
-#endif
-    assert(false && "Decoder: unreachable!");
   }
   return InstPtr;
 };

--- a/lib/Memory.cpp
+++ b/lib/Memory.cpp
@@ -3,23 +3,27 @@
 #include <iostream>
 
 void Memory::writeByte(Address Ad, Byte Val){
+  // FIXME: raise access fault for address like x < DRAM_BASE ?
   Address DRAM_Ad = Ad - DRAM_BASE;
   DRAM[DRAM_Ad] = Val & 0xff;
 }
 
 Byte Memory::readByte(Address Ad){
+  // FIXME: raise access fault for address like x < DRAM_BASE ?
   Address DRAM_Ad = Ad - DRAM_BASE;
   Byte Val = DRAM[DRAM_Ad];
   return Val;
 }
 
 void Memory::writeHalfWord(Address Ad, HalfWord Val){
+  // FIXME: raise access fault for address like x < DRAM_BASE ?
   Address DRAM_Ad = Ad - DRAM_BASE;
   DRAM[DRAM_Ad] = Val & 0xff;
   DRAM[DRAM_Ad + 1] = (Val >> 8) & 0xff;
 }
 
 HalfWord Memory::readHalfWord(Address Ad){
+  // FIXME: raise access fault for address like x < DRAM_BASE ?
   Address DRAM_Ad = Ad - DRAM_BASE;
   HalfWord Val = DRAM[DRAM_Ad] + (DRAM[DRAM_Ad + 1] << 8);
   return Val;


### PR DESCRIPTION
So far, the Simulator decodes all input bytes ahead of time, but the real binary, like riscv-tests or dhrystone, contains data sections. So change it to just in time.